### PR TITLE
Allow Carbon 2 to be installed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "arvenil/ninja-mutex": "0.6.0",
         "league/csv": "8.0",
         "laravel/framework": "^5.1",
-        "nesbot/carbon": "~1.20"
+        "nesbot/carbon": "^1.20 || ^2.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Brings the Carbon dependency constraint inline with the later versions of Laravel https://github.com/laravel/framework/blob/5.8/composer.json#L28