### PR TITLE
Add support for Laravel 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": ">=5.6.4",
         "arvenil/ninja-mutex": "0.6.0",
         "league/csv": "8.0",
-        "laravel/framework": "^5.1",
+        "laravel/framework": "^5.1 || ^6.0",
         "nesbot/carbon": "^1.20 || ^2.0"
     },
     "autoload": {

--- a/src/BaseCsvImporter.php
+++ b/src/BaseCsvImporter.php
@@ -1492,9 +1492,9 @@ abstract class BaseCsvImporter
      */
     public static function flushFilters($type)
     {
-        $filters = static::${$type . 'Filters'};
+        static::${$type . 'Filters'}[static::class] = [];
 
-        return Arr::set($filters, static::class, []);
+        return static::${$type . 'Filters'}[static::class];
     }
 
     /**


### PR DESCRIPTION
Allows the package to be installed in Laravel 6.
Changes flush filters to match the expected behaviour in the phpunit tests